### PR TITLE
fix: cann't withdraw uncollateralized nft asset when hf < 1

### DIFF
--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -321,7 +321,18 @@ library SupplyLogic {
 
         ValidationLogic.validateWithdrawERC721(reserveCache);
 
-        if (userConfig.isUsingAsCollateral(reserve.id)) {
+        bool hasAnyCollateralAsset = false;
+        for (uint256 index = 0; index < params.tokenIds.length; index++) {
+            if (
+                ICollaterizableERC721(reserveCache.xTokenAddress)
+                    .isUsedAsCollateral(params.tokenIds[index])
+            ) {
+                hasAnyCollateralAsset = true;
+                break;
+            }
+        }
+
+        if (hasAnyCollateralAsset) {
             if (userConfig.isBorrowingAny()) {
                 ValidationLogic.validateHFAndLtv(
                     reservesData,


### PR DESCRIPTION
## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
