### PR TITLE
fix: should check hasAnyCollateralAsset before burn nToken

### DIFF
--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -310,16 +310,9 @@ library SupplyLogic {
         DataTypes.ReserveData storage reserve = reservesData[params.asset];
         DataTypes.ReserveCache memory reserveCache = reserve.cache();
 
+        ValidationLogic.validateWithdrawERC721(reserveCache);
         reserve.updateState(reserveCache);
         uint256 amountToWithdraw = params.tokenIds.length;
-
-        bool withdrwingAllCollateral = INToken(reserveCache.xTokenAddress).burn(
-            msg.sender,
-            params.to,
-            params.tokenIds
-        );
-
-        ValidationLogic.validateWithdrawERC721(reserveCache);
 
         bool hasAnyCollateralAsset = false;
         for (uint256 index = 0; index < params.tokenIds.length; index++) {
@@ -331,6 +324,12 @@ library SupplyLogic {
                 break;
             }
         }
+
+        bool withdrwingAllCollateral = INToken(reserveCache.xTokenAddress).burn(
+            msg.sender,
+            params.to,
+            params.tokenIds
+        );
 
         if (hasAnyCollateralAsset) {
             if (userConfig.isBorrowingAny()) {


### PR DESCRIPTION
## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
