### PR TITLE
fix: nDOODLE address and add back missing marketplace checkes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,10 @@ deploy-renounceOwnership:
 ad-hoc:
 	make SCRIPT_PATH=./deploy/tasks/deployments/dev/1.ad-hoc.ts run
 
+.PHONY: info
+info:
+	make SCRIPT_PATH=./deploy/tasks/deployments/dev/3.info.ts run
+
 .PHONY: transfer-tokens
 transfer-tokens:
 	make SCRIPT_PATH=./deploy/tasks/deployments/dev/2.transfer-tokens.ts run

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -110,7 +110,7 @@ const hardhatConfig: HardhatUserConfig = {
   networks: {
     anvil: {
       chainId: CHAINS_ID[eEthereumNetwork.anvil],
-      url: "http://localhost:8545",
+      url: NETWORKS_RPC_URL[eEthereumNetwork.anvil],
       accounts: [
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",

--- a/test/_pool_marketplace_buy_with_credit.spec.ts
+++ b/test/_pool_marketplace_buy_with_credit.spec.ts
@@ -1357,6 +1357,7 @@ describe("Leveraged Buy - Positive tests", () => {
   it("TC-erc721-buy-15: ERC721 <=> ERC20 via Looksrare - no loan", async () => {
     const {
       doodles,
+      nDOODLE,
       dai,
       transferManagerERC721,
       pool,
@@ -1394,11 +1395,20 @@ describe("Leveraged Buy - Positive tests", () => {
       maker,
       taker
     );
+
+    expect(await doodles.balanceOf(maker.address)).to.be.eq(0);
+    expect(await doodles.ownerOf(nftId)).to.be.eq(
+      (await pool.getReserveData(doodles.address)).xTokenAddress
+    );
+    expect(await nDOODLE.balanceOf(taker.address)).to.be.eq(1);
+    expect(await nDOODLE.ownerOf(nftId)).to.be.eq(taker.address);
+    expect(await dai.balanceOf(maker.address)).to.be.eq(startAmount);
   });
 
   it("TC-erc721-buy-23: ERC721 <=> ERC20 via Blur - no loan", async () => {
     const {
       doodles,
+      nDOODLE,
       weth,
       executionDelegate,
       pool,
@@ -1436,6 +1446,14 @@ describe("Leveraged Buy - Positive tests", () => {
       maker,
       taker
     );
+
+    expect(await doodles.balanceOf(maker.address)).to.be.eq(0);
+    expect(await doodles.ownerOf(nftId)).to.be.eq(
+      (await pool.getReserveData(doodles.address)).xTokenAddress
+    );
+    expect(await nDOODLE.balanceOf(taker.address)).to.be.eq(1);
+    expect(await nDOODLE.ownerOf(nftId)).to.be.eq(taker.address);
+    expect(await weth.balanceOf(maker.address)).to.be.eq(startAmount);
   });
 });
 

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -160,7 +160,7 @@ export interface TestEnv {
   ape: MintableERC20;
   nMAYC: NTokenMAYC;
   mayc: MintableERC721;
-  nDOODLES: NToken;
+  nDOODLE: NToken;
   doodles: MintableERC721;
   mockTokenFaucet: MockTokenFaucet;
   wPunkGateway: WPunkGateway;
@@ -337,8 +337,8 @@ export async function initializeMakeSuite() {
     (xToken) => xToken.symbol === NTokenContractId.nMAYC
   )?.tokenAddress;
 
-  const nDOODLESAddress = allTokens.find(
-    (xToken) => xToken.symbol === NTokenContractId.nDOODLES
+  const nDOODLEAddress = allTokens.find(
+    (xToken) => xToken.symbol === NTokenContractId.nDOODLE
   )?.tokenAddress;
 
   const nWPunkAddress = allTokens.find(
@@ -449,7 +449,7 @@ export async function initializeMakeSuite() {
 
   testEnv.nBAYC = await getNTokenBAYC(nBAYCAddress);
   testEnv.nMAYC = await getNTokenMAYC(nMAYCAddress);
-  testEnv.nDOODLES = await getNToken(nDOODLESAddress);
+  testEnv.nDOODLE = await getNToken(nDOODLEAddress);
 
   testEnv.nMOONBIRD = await getNTokenMoonBirds(nMOONBIRDAddress);
 


### PR DESCRIPTION
Signed-off-by: GopherJ <alex_cj96@foxmail.com>

## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
