### PR TITLE
fix: make auction closable when erc721HF is equal to auctionRecoveryHF

### DIFF
--- a/contracts/protocol/libraries/logic/ValidationLogic.sol
+++ b/contracts/protocol/libraries/logic/ValidationLogic.sol
@@ -831,7 +831,7 @@ library ValidationLogic {
         );
 
         require(
-            params.erc721HealthFactor > params.auctionRecoveryHealthFactor,
+            params.erc721HealthFactor >= params.auctionRecoveryHealthFactor,
             Errors.ERC721_HEALTH_FACTOR_NOT_ABOVE_THRESHOLD
         );
     }

--- a/contracts/protocol/pool/PoolParameters.sol
+++ b/contracts/protocol/pool/PoolParameters.sol
@@ -279,7 +279,7 @@ contract PoolParameters is
                 ADDRESSES_PROVIDER.getPriceOracle()
             );
         require(
-            erc721HealthFactor > ps._auctionRecoveryHealthFactor,
+            erc721HealthFactor >= ps._auctionRecoveryHealthFactor,
             Errors.ERC721_HEALTH_FACTOR_NOT_ABOVE_THRESHOLD
         );
         userConfig.auctionValidityTime = block.timestamp;


### PR DESCRIPTION
Signed-off-by: GopherJ <alex_cj96@foxmail.com>

## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
