### PR TITLE
Fix: Anycall exists in AirdropFlashClaimReceiver

### DIFF
--- a/contracts/misc/flashclaim/AirdropFlashClaimReceiver.sol
+++ b/contracts/misc/flashclaim/AirdropFlashClaimReceiver.sol
@@ -61,11 +61,12 @@ contract AirdropFlashClaimReceiver is
     function executeOperation(
         address nftAsset,
         uint256[] calldata nftTokenIds,
+        address initiator,
         bytes calldata params
     ) external override onlyPool returns (bool) {
         require(nftTokenIds.length > 0, "empty token list");
+        require(initiator == owner(), "not owner");
 
-        address initiator = owner();
         ExecuteOperationLocalVars memory vars;
         // decode parameters
         (

--- a/contracts/misc/interfaces/IFlashClaimReceiver.sol
+++ b/contracts/misc/interfaces/IFlashClaimReceiver.sol
@@ -9,6 +9,7 @@ interface IFlashClaimReceiver {
     function executeOperation(
         address asset,
         uint256[] calldata tokenIds,
+        address initiator,
         bytes calldata params
     ) external returns (bool);
 }

--- a/contracts/protocol/libraries/logic/FlashClaimLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashClaimLogic.sol
@@ -47,6 +47,7 @@ library FlashClaimLogic {
             IFlashClaimReceiver(params.receiverAddress).executeOperation(
                 params.nftAsset,
                 params.nftTokenIds,
+                msg.sender,
                 params.params
             ),
             Errors.INVALID_FLASH_CLAIM_RECEIVER

--- a/test/_pool_core_flash_claim.spec.ts
+++ b/test/_pool_core_flash_claim.spec.ts
@@ -371,4 +371,29 @@ describe("Flash Claim Test", () => {
       ProtocolErrors.HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD
     );
   });
+
+  it("TC-flash-claim-06:user can not flash claim use others receiver", async function () {
+    const {
+      users: [user1, user2],
+      bayc,
+      pool,
+    } = testEnv;
+
+    const user_registry = await getUserFlashClaimRegistry();
+    await user_registry.connect(user2.signer).createReceiver();
+    const flashClaimReceiverAddr = await user_registry.userReceivers(
+      user2.address
+    );
+
+    await expect(
+      pool
+        .connect(user1.signer)
+        .flashClaim(
+          flashClaimReceiverAddr,
+          bayc.address,
+          [0],
+          receiverEncodedData
+        )
+    ).to.be.revertedWith("not owner");
+  });
 });


### PR DESCRIPTION
## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
