### PR TITLE
fix: add waitForTx

### DIFF
--- a/test/_pool_configurator.spec.ts
+++ b/test/_pool_configurator.spec.ts
@@ -944,24 +944,38 @@ describe("PoolConfigurator: Drop Reserve", () => {
     const borrowedAmount = utils.parseEther("100");
     const depositedAmount = utils.parseEther("1000");
     // setting reserve factor to 0 to ease tests, no xToken accrued in reserve
-    await configurator.setReserveFactor(dai.address, 0);
-    await dai["mint(uint256)"](depositedAmount);
-    await dai.approve(pool.address, depositedAmount);
-    await dai.connect(user1.signer)["mint(uint256)"](depositedAmount);
-    await dai.connect(user1.signer).approve(pool.address, depositedAmount);
-    await weth.connect(user1.signer)["mint(uint256)"](depositedAmount);
-    await weth.connect(user1.signer).approve(pool.address, depositedAmount);
+    await waitForTx(await configurator.setReserveFactor(dai.address, 0));
+    await waitForTx(await dai["mint(uint256)"](depositedAmount));
+    await waitForTx(await dai.approve(pool.address, depositedAmount));
+    await waitForTx(
+      await dai.connect(user1.signer)["mint(uint256)"](depositedAmount)
+    );
+    await waitForTx(
+      await dai.connect(user1.signer).approve(pool.address, depositedAmount)
+    );
+    await waitForTx(
+      await weth.connect(user1.signer)["mint(uint256)"](depositedAmount)
+    );
+    await waitForTx(
+      await weth.connect(user1.signer).approve(pool.address, depositedAmount)
+    );
 
-    await pool.supply(dai.address, depositedAmount, deployer.address, 0);
+    await waitForTx(
+      await pool.supply(dai.address, depositedAmount, deployer.address, 0)
+    );
     await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(
       XTOKEN_SUPPLY_NOT_ZERO
     );
-    await pool
-      .connect(user1.signer)
-      .supply(weth.address, depositedAmount, user1.address, 0);
-    await pool
-      .connect(user1.signer)
-      .borrow(dai.address, borrowedAmount, 0, user1.address);
+    await waitForTx(
+      await pool
+        .connect(user1.signer)
+        .supply(weth.address, depositedAmount, user1.address, 0)
+    );
+    await waitForTx(
+      await pool
+        .connect(user1.signer)
+        .borrow(dai.address, borrowedAmount, 0, user1.address)
+    );
     await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(
       VARIABLE_DEBT_SUPPLY_NOT_ZERO
     );


### PR DESCRIPTION
Signed-off-by: GopherJ <alex_cj96@foxmail.com>

## Security Checklist

- [ ] 1. Re-Entrancy
- [ ] 2. Arithmetic Over/Under Flows
- [ ] 3. Unexpected Ether
- [ ] 4. Delegatecall
- [ ] 5. Default Visibilities
- [ ] 6. Entropy Illusion
- [ ] 7. External Contract Referencing
- [ ] 8. Short Address/Parameter Attack (off chain)
- [ ] 9. Unchecked CALL Return Values
- [ ] 10. Race Conditions / Front Running
- [ ] 11. Denial Of Service (DOS)
- [ ] 12. Block Timestamp Manipulation
- [ ] 13. Constructors with Care
- [ ] 14. Uninitialized Storage Pointers
- [ ] 15. Floating Points and Precision
- [ ] 16. Tx.Origin Authentication
- [ ] 17. Address.isContract Re-Entrancy via Constructor

### ⚠️ NOTES ⚠️

Make sure to think about each of these exploits in this PR.
